### PR TITLE
fix: 🐛 a stable release of a package should not have a prerelease dep…

### DIFF
--- a/src/backend/NSExt/NSExt.csproj
+++ b/src/backend/NSExt/NSExt.csproj
@@ -7,7 +7,7 @@
     <Import Project="$(SolutionDir)/build/copy.pkg.xml.comment.files.targets"/>
     <Import Project="$(SolutionDir)/build/prebuild.targets"/>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0-3.final"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.11.0"/>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0"/>
         <PackageReference Include="System.IO.Hashing" Version="9.0.0"/>
     </ItemGroup>


### PR DESCRIPTION
…endency

[skip ci]